### PR TITLE
feat: Clientside stacktraces for ARM64 [NATIVE-289] (#54)

### DIFF
--- a/libunwind/src/UnwindCursor.hpp
+++ b/libunwind/src/UnwindCursor.hpp
@@ -1970,10 +1970,8 @@ void UnwindCursor<A, R>::setInfoBasedOnIPRegister(bool isReturnAddress) {
   #endif
         // If unwind table has entry, but entry says there is no unwind info,
         // record that we have no unwind info.
-#ifndef _LIBUNWIND_TARGET_X86_64
-        if (_info.format == 0)
-          _unwindInfoMissing = true;
-#endif
+        // if (_info.format == 0)
+        //   _unwindInfoMissing = true;
         return;
       }
     }


### PR DESCRIPTION
The changes that were needed to make this work:

* strip the pointer-authentication code from instruction addresses we read
   do speculative link-register or frame-pointer based unwinding if we have a 0 compact encoding.

Co-authored-by: Jan Michael Auer <mail@jauer.org>
Co-authored-by: Arpad Borsos <swatinem@swatinem.de>
Co-authored-by: Arpad Borsos <arpad.borsos@sentry.io>