### PR TITLE
feat(STAFF-139596): kill child processes on crashes for macOS

### DIFF
--- a/handler/mac/crash_report_exception_handler.cc
+++ b/handler/mac/crash_report_exception_handler.cc
@@ -269,6 +269,8 @@ kern_return_t CrashReportExceptionHandler::CatchMachException(
   ExcServerCopyState(
       behavior, old_state, old_state_count, new_state, new_state_count);
 
+  td::KillChildProcesses(std::to_string(pid));
+
   Metrics::ExceptionCaptureResult(Metrics::CaptureResult::kSuccess);
   return ExcServerSuccessfulReturnValue(exception, behavior, false);
 }

--- a/handler/relaunch_signal.cc
+++ b/handler/relaunch_signal.cc
@@ -64,26 +64,6 @@ std::string getChildProcessList(const std::string& ppid) {
   return result;
 }
 
-void killCrashedPidChildren(const std::string& pid) {
-  // if crashed process has children kill them
-  auto cmdOutput = getChildProcessList(pid);
-  if (!cmdOutput.empty()) {
-    std::istringstream stream(cmdOutput);
-    for (std::string line; std::getline(stream, line);) {
-      if (!line.empty()) {
-#if defined(WIN32)
-        const auto explorer = OpenProcess(PROCESS_TERMINATE, false, stoul(line));
-        TerminateProcess(explorer, 1);
-        CloseHandle(explorer);
-#else
-        int pid = std::stoi(line);
-        ::kill(static_cast<pid_t>(pid), SIGKILL);
-#endif
-      }
-    }
-  }
-}
-
 std::vector<char*> getRelaunchArgv(const std::string& argvStr,
                                    const std::string& pidCrashed,
                                    bool& maybeCrashLoop) {
@@ -164,6 +144,25 @@ void SetCrashed() {
   crashed = true;
 }
 
+void KillChildProcesses(const std::string& pid) {
+  auto cmdOutput = getChildProcessList(pid);
+  if (!cmdOutput.empty()) {
+    std::istringstream stream(cmdOutput);
+    for (std::string line; std::getline(stream, line);) {
+      if (!line.empty()) {
+#if defined(WIN32)
+        const auto explorer = OpenProcess(PROCESS_TERMINATE, false, stoul(line));
+        TerminateProcess(explorer, 1);
+        CloseHandle(explorer);
+#else
+        int pid = std::stoi(line);
+        ::kill(static_cast<pid_t>(pid), SIGKILL);
+#endif
+      }
+    }
+  }
+}
+
 void RelaunchOnCrash(const std::map<std::string, std::string>& annotations) {
   if (crashed) {
     auto appPath = annotations.find("__td-relaunch-path");
@@ -182,7 +181,7 @@ void RelaunchOnCrash(const std::map<std::string, std::string>& annotations) {
                 << appPath->second.c_str() << " (" << pidCrashed->second.c_str()
                 << ") maybeCrashLoop=" << maybeCrashLoop << " ARGS=" << argvStr;
 
-      killCrashedPidChildren(pidCrashed->second);
+      KillChildProcesses(pidCrashed->second);
 
       if (!maybeCrashLoop) {
 #if defined(WIN32)

--- a/handler/relaunch_signal.h
+++ b/handler/relaunch_signal.h
@@ -7,6 +7,8 @@
 namespace td {
   void SetCrashed();
 
+  void KillChildProcesses(const std::string& pid);
+
   void RelaunchOnCrash(const std::map<std::string, std::string>& annotations);
 }
 


### PR DESCRIPTION
- Moved **_killCrashedPidChildren_** as-is into the **_td_** namespace with the name **_KillChildProcesses_**
- Called **_KillChildProcesses_** on crashes for macOS